### PR TITLE
remove holder package

### DIFF
--- a/packages/activitypub-core-endpoints/package.json
+++ b/packages/activitypub-core-endpoints/package.json
@@ -26,7 +26,6 @@
     "activitypub-core-utilities": "^0.0.190",
     "cookie": "^0.5.0",
     "formidable": "^2.0.1",
-    "http": "^0.0.1-security",
     "query-string": "^7.1.1",
     "superjson": "^1.10.1"
   },

--- a/packages/activitypub-core-server-express/package.json
+++ b/packages/activitypub-core-server-express/package.json
@@ -30,8 +30,7 @@
     "activitypub-core-endpoints": "^0.0.190",
     "activitypub-core-types": "^0.0.190",
     "activitypub-core-utilities": "^0.0.190",
-    "express": "^4.18.2",
-    "http": "^0.0.1-security"
+    "express": "^4.18.2"
   },
   "gitHead": "feeaebe7fed149c7080810e9347801a7a8605d36"
 }


### PR DESCRIPTION
Just a small thing i noticed; `http` is a built-in, not an npm module. Keep up the good work, very interested to see where this will go!