### PR TITLE
WebfingerGetEndpoint does not return 404 if username is falsy

### DIFF
--- a/packages/activitypub-core-endpoints/src/webfinger/index.ts
+++ b/packages/activitypub-core-endpoints/src/webfinger/index.ts
@@ -52,10 +52,6 @@ export class WebfingerGetEndpoint {
     const [account] = resource.split('@');
     const [, username] = account.split(':');
 
-    if (!username) {
-      return this.handleNotFound();
-    }
-    
     const actor = await this.adapters.db.findOne('entity', {
       preferredUsername: username,
     }, [DbOptions.CASE_INSENSITIVE]);


### PR DESCRIPTION
Motivation:
* use this lib for no-username ActivityPub actors

Details
* I was trying out this library as a way of serving an ActivityPub actor at the root of a domain (e.g. 'me.com/'), and having mastodon access it.
* mastodon makes a request like `http://3445-2605-a601-af8f-a700-d137-4ef4-e90b-5630.ngrok.io/.well-known/webfinger?resource=acct:@3445-2605-a601-af8f-a700-d137-4ef4-e90b-5630.ngrok.io`
  * note the acct uri like `acct:@3...` with an empty `userpart` (which is valid)
* because the empty string acct uri `userpart` is falsy in javascript, the prior code here returns a 404 before my db adapter has a chance to return something

While I understand why this falsy username check is in there, I think the library will be slightly be more useful without it. After all, if the db adapter returns falsy immediately after, the endpoint will do the same `handleNotFound()`, so it seems like this change has little downsides.

wdyt?
